### PR TITLE
Deployment fixes

### DIFF
--- a/fw/Cargo.toml
+++ b/fw/Cargo.toml
@@ -10,18 +10,19 @@ edition = "2021"
 license = "GPL-3.0"
 publish = false
 
-default-target = "nanosplus"
+# default-target = "nanosplus"
 
 [package.metadata.nanos]
+name = "MobileCoin"
 curve = [ "ed25519" ]
 path = [ 
     "44'/866'",
     "13'/",
 ]
 flags = "0"
-icon = "mob16x16i.gif"
-icon_small = "mob14x14i.gif"
-#api_level = "1"
+icon = "assets/mob16x16i.gif"
+icon_small = "assets/mob14x14i.gif"
+api_level = "1"
 
 [features]
 applet = []

--- a/ledger_app.toml
+++ b/ledger_app.toml
@@ -1,0 +1,3 @@
+[rust-app]
+manifest-path = "fw/Cargo.toml"
+


### PR DESCRIPTION
This PR enables deployment of the app for Ledger Live.
A manifest that points to where the app's code lives is used, and also discriminates Rust vs C apps easily (as suggested by @ryankurte)

Changes required:
- name to be displayed on the Nano and Store
- fixing paths to icons
- removing the `default-target` which seems to confuse `cargo` when using a different target

the api_level flag is actually ignored during deployment, but is needed when sideloading now.
