### PR TITLE
Only Nano S+ is currently supported

### DIFF
--- a/ledger_app.toml
+++ b/ledger_app.toml
@@ -1,4 +1,4 @@
 [app]
 build_directory = "./fw/"
 sdk = "Rust"
-devices = ["nanox", "nanos+"]
+devices = ["nanos+"]


### PR DESCRIPTION
NanoX is not supported (see issue #27), so it is useless to build it.

Moreover, when building the fw for Nano X in [ledger-app-builder](https://github.com/LedgerHQ/ledger-app-builder/tree/master/full), through `cargo ledger build nanox` and using NanoX custom target file (see target NanoX defined [here](https://github.com/LedgerHQ/ledger-device-rust-sdk/blob/master/ledger_device_sdk/nanox.json)) which is available in the container, there is an issue with `heapless` crate build:

````
error[E0599]: no method named `compare_exchange_weak` found for reference `&AtomicU8` in the current scope
   --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/mpmc.rs:226:18
    |
225 |               if dequeue_pos
    |  ________________-
226 | |                 .compare_exchange_weak(
    | |                 -^^^^^^^^^^^^^^^^^^^^^ method not found in `&AtomicU8`
    | |_________________|
    |

error[E0599]: no method named `compare_exchange_weak` found for reference `&AtomicU8` in the current scope
   --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/mpmc.rs:266:18
    |
265 |               if enqueue_pos
    |  ________________-
266 | |                 .compare_exchange_weak(
    | |                 -^^^^^^^^^^^^^^^^^^^^^ method not found in `&AtomicU8`
    | |_________________|
    |

error[E0599]: no method named `fetch_add` found for struct `AtomicUsize` in the current scope
   --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/pool/singleton/arc.rs:259:44
    |
259 |         let old_size = self.inner().strong.fetch_add(1, Ordering::Relaxed);
    |                                            ^^^^^^^^^ method not found in `AtomicUsize`

error[E0599]: no method named `fetch_sub` found for struct `AtomicUsize` in the current scope
   --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/pool/singleton/arc.rs:307:32
    |
307 |         if self.inner().strong.fetch_sub(1, Ordering::Release) != 1 {
    |                                ^^^^^^^^^ method not found in `AtomicUsize`

error[E0599]: no method named `compare_exchange_weak` found for struct `AtomicPtr` in the current scope
  --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/pool/llsc.rs:43:29
   |
43 |             match self.head.compare_exchange_weak(
   |                   ----------^^^^^^^^^^^^^^^^^^^^^ method not found in `AtomicPtr<Node<T>>`

error[E0599]: no method named `compare_exchange_weak` found for struct `AtomicPtr` in the current scope
  --> /opt/.cargo/registry/src/index.crates.io-6f17d22bba15001f/heapless-0.7.16/src/pool/llsc.rs:64:33
   |
64 |                 match self.head.compare_exchange_weak(
   |                       ----------^^^^^^^^^^^^^^^^^^^^^ method not found in `AtomicPtr<Node<T>>`

   Compiling hmac v0.12.1
For more information about this error, try `rustc --explain E0599`.
error: could not compile `heapless` (lib) due to 6 previous errors
````

This issue may be due to https://doc.rust-lang.org/std/sync/atomic/index.html#portability.
 The issue is not seen when building with the target file provided in the repo (i.e. `fw/nanox.json`) with `cargo build --targe ./nanox.json --release`
 
When comparing both target files (Ledger vs Mobilecoin), there are significant differences, for instance `llvm-target`.

As nowadays NanoX is not supported, I propose to build only for Nano S+ device.